### PR TITLE
Replaced System.Drawing.Common with ImageSharp

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Converted to .NET Core by Brian Berns.
 
 [![Build status](https://ci.appveyor.com/api/projects/status/ts22h5vdkjej9j25?svg=true)](https://ci.appveyor.com/project/NikolayIT/rtfdomparser)
 
-**NuGet:** https://www.nuget.org/packages/RtfDomParser/
+**NuGet:** https://www.nuget.org/packages/RtfDomParserCore/
 
 ## Features
 * Parse RTF and generate dom tree.

--- a/Source/RtfDomParser/DocumentFormatInfo.cs
+++ b/Source/RtfDomParser/DocumentFormatInfo.cs
@@ -9,8 +9,9 @@
 
 using System;
 using System.ComponentModel;
-using System.Drawing;
-using System.Drawing.Drawing2D;
+using RtfDomParser.Utils;
+using SixLabors.Fonts;
+using SixLabors.ImageSharp;
 
 namespace RtfDomParser
 {
@@ -95,7 +96,7 @@ namespace RtfDomParser
 
         private bool bolBottomBorder = false;
         /// <summary>
-        /// ÊÇ·ñÏÔÊ¾ÏÂ±ß¿òÏß
+        /// ï¿½Ç·ï¿½ï¿½ï¿½Ê¾ï¿½Â±ß¿ï¿½ï¿½ï¿½
         /// </summary>
         [DefaultValue(false)]
         public bool BottomBorder
@@ -110,13 +111,13 @@ namespace RtfDomParser
             }
         }
 
-        private System.Drawing.Color intBorderColor
-            = System.Drawing.Color.Black;
+        private Color intBorderColor
+            = Color.Black;
         /// <summary>
         /// Border line color
         /// </summary>
-        [DefaultValue(typeof(System.Drawing.Color), "Black")]
-        public System.Drawing.Color BorderColor
+        [DefaultValue(typeof(Color), "Black")]
+        public Color BorderColor
         {
             get
             {
@@ -147,7 +148,7 @@ namespace RtfDomParser
 
         private DashStyle _BorderStyle = DashStyle.Solid;
         /// <summary>
-        /// ±ß¿òÏßÑùÊ½
+        /// ï¿½ß¿ï¿½ï¿½ï¿½ï¿½ï¿½Ê½
         /// </summary>
         [DefaultValue( DashStyle.Solid )]
         public DashStyle BorderStyle
@@ -164,7 +165,7 @@ namespace RtfDomParser
 
         private bool _BorderThickness = false;
         /// <summary>
-        /// ²ÉÓÃ´Ö±ß¿òÏßÑùÊ½
+        /// ï¿½ï¿½ï¿½Ã´Ö±ß¿ï¿½ï¿½ï¿½ï¿½ï¿½Ê½
         /// </summary>
         [DefaultValue( false )]
         public bool BorderThickness
@@ -181,7 +182,7 @@ namespace RtfDomParser
 
         private int _BorderSpacing = 0;
         /// <summary>
-        /// ±ß¿òÏß¾àÀë
+        /// ï¿½ß¿ï¿½ï¿½ß¾ï¿½ï¿½ï¿½
         /// </summary>
         [DefaultValue( 0 )]
         public int BorderSpacing
@@ -356,7 +357,7 @@ namespace RtfDomParser
 
         private bool _PageBreak = false;
         /// <summary>
-        /// ¶ÎÂäÇ°Ç¿ÖÆ·ÖÒ³
+        /// ï¿½ï¿½ï¿½ï¿½Ç°Ç¿ï¿½Æ·ï¿½Ò³
         /// </summary>
         [DefaultValue( false )]
         public bool PageBreak
@@ -370,13 +371,13 @@ namespace RtfDomParser
         /// </summary>
         public int NativeLevel = 0;
 
-        public void SetAlign(System.Drawing.StringAlignment align)
+        public void SetAlign(StringAlignment align)
         {
-            if (align == System.Drawing.StringAlignment.Center)
+            if (align == StringAlignment.Center)
             {
                 this.Align = RTFAlignment.Center;
             }
-            else if (align == System.Drawing.StringAlignment.Far)
+            else if (align == StringAlignment.Far)
             {
                 this.Align = RTFAlignment.Right;
             }
@@ -387,7 +388,7 @@ namespace RtfDomParser
         }
 
         [Browsable(false)]
-        public System.Drawing.Font Font
+        public Font Font
         {
             set
             {
@@ -395,10 +396,10 @@ namespace RtfDomParser
                 {
                     FontName = value.Name;
                     FontSize = value.Size;
-                    Bold = value.Bold;
-                    Italic = value.Italic;
-                    Underline = value.Underline;
-                    Strikeout = value.Strikeout;
+                    Bold = value.IsBold;
+                    Italic = value.IsItalic;
+                    // TODO Underline = value.Underline;
+                    // TODO Strikeout = value.Strikeout;
                 }
             }
         }
@@ -528,12 +529,12 @@ namespace RtfDomParser
             }
         }
 
-        private System.Drawing.Color intTextColor = System.Drawing.Color.Black;
+        private Color intTextColor = Color.Black;
         /// <summary>
         /// text color
         /// </summary>
-        [DefaultValue(typeof(System.Drawing.Color), "Black")]
-        public System.Drawing.Color TextColor
+        [DefaultValue(typeof(Color), "Black")]
+        public Color TextColor
         {
             get
             {
@@ -545,12 +546,12 @@ namespace RtfDomParser
             }
         }
 
-        private System.Drawing.Color intBackColor = System.Drawing.Color.Empty;
+        private Color intBackColor = ImageTools.ColorEmpty;
         /// <summary>
         /// back color
         /// </summary>
-        [DefaultValue(typeof(System.Drawing.Color), "Empty")]
-        public System.Drawing.Color BackColor
+        [DefaultValue(typeof(Color), "Empty")]
+        public Color BackColor
         {
             get
             {
@@ -563,9 +564,9 @@ namespace RtfDomParser
         }
 
         ///// <summary>
-        ///// ±ß¿òÏßÑÕÉ«
+        ///// ï¿½ß¿ï¿½ï¿½ï¿½ï¿½ï¿½É«
         ///// </summary>
-        //public System.Drawing.Color BorderColor = System.Drawing.Color.Empty;
+        //public Color BorderColor = Color.Empty;
         private string strLink = null;
         /// <summary>
         /// link
@@ -818,8 +819,8 @@ namespace RtfDomParser
             this.Italic = false;
             this.Underline = false;
             this.Strikeout = false;
-            this.TextColor = System.Drawing.Color.Black;
-            this.BackColor = System.Drawing.Color.Empty;
+            this.TextColor = Color.Black;
+            this.BackColor = ImageTools.ColorEmpty;
             //this.Link = null ;
             this.Subscript = false;
             this.Superscript = false;
@@ -858,7 +859,7 @@ namespace RtfDomParser
             //this.TopBorder = false;
             //this.RightBorder = false;
             //this.BottomBorder = false;
-            //this.BorderColor = System.Drawing.Color.Transparent;
+            //this.BorderColor = Color.Transparent;
         }
 
         public void Reset()
@@ -883,8 +884,8 @@ namespace RtfDomParser
             this.Italic = false;
             this.Underline = false;
             this.Strikeout = false;
-            this.TextColor = System.Drawing.Color.Black;
-            this.BackColor = System.Drawing.Color.Empty;
+            this.TextColor = Color.Black;
+            this.BackColor = ImageTools.ColorEmpty;
             this.Link = null;
             this.Subscript = false;
             this.Superscript = false;
@@ -969,7 +970,7 @@ namespace RtfDomParser
 
 //        private RTFBorderStyle _Border = new RTFBorderStyle();
 //        /// <summary>
-//        /// ±ß¿òÑùÊ½
+//        /// ï¿½ß¿ï¿½ï¿½ï¿½Ê½
 //        /// </summary>
 //        public RTFBorderStyle Border
 //        {
@@ -979,7 +980,7 @@ namespace RtfDomParser
 
 //        private RTFBorderStyle _ParagraphBorder = new RTFBorderStyle();
 //        /// <summary>
-//        /// ¶ÎÂä±ß¿òÑùÊ½
+//        /// ï¿½ï¿½ï¿½ï¿½ß¿ï¿½ï¿½ï¿½Ê½
 //        /// </summary>
 //        public RTFBorderStyle ParagraphBorder
 //        {
@@ -1128,13 +1129,13 @@ namespace RtfDomParser
 //        /// </summary>
 //        public int NativeLevel = 0;
 
-//        public void SetAlign( System.Drawing.StringAlignment align )
+//        public void SetAlign( StringAlignment align )
 //        {
-//            if (align == System.Drawing.StringAlignment.Center)
+//            if (align == StringAlignment.Center)
 //            {
 //                this.Align = RTFAlignment.Center;
 //            }
-//            else if (align == System.Drawing.StringAlignment.Far)
+//            else if (align == StringAlignment.Far)
 //            {
 //                this.Align = RTFAlignment.Right;
 //            }
@@ -1145,7 +1146,7 @@ namespace RtfDomParser
 //        }
         
 //        [Browsable( false )]
-//        public System.Drawing.Font Font
+//        public Font Font
 //        {
 //            set
 //            {
@@ -1280,12 +1281,12 @@ namespace RtfDomParser
 //            }
 //        }
 
-//        private System.Drawing.Color intTextColor = System.Drawing.Color.Black;
+//        private Color intTextColor = Color.Black;
 //        /// <summary>
 //        /// text color
 //        /// </summary>
-//        [DefaultValue(typeof(System.Drawing.Color), "Black")]
-//        public System.Drawing.Color TextColor
+//        [DefaultValue(typeof(Color), "Black")]
+//        public Color TextColor
 //        {
 //            get
 //            {
@@ -1297,12 +1298,12 @@ namespace RtfDomParser
 //            }
 //        }
 
-//        private System.Drawing.Color intBackColor = System.Drawing.Color.Empty;
+//        private Color intBackColor = Color.Empty;
 //        /// <summary>
 //        /// back color
 //        /// </summary>
-//        [DefaultValue(typeof(System.Drawing.Color), "Empty")]
-//        public System.Drawing.Color BackColor
+//        [DefaultValue(typeof(Color), "Empty")]
+//        public Color BackColor
 //        {
 //            get
 //            {
@@ -1315,9 +1316,9 @@ namespace RtfDomParser
 //        }
 
 //        ///// <summary>
-//        ///// ±ß¿òÏßÑÕÉ«
+//        ///// ï¿½ß¿ï¿½ï¿½ï¿½ï¿½ï¿½É«
 //        ///// </summary>
-//        //public System.Drawing.Color BorderColor = System.Drawing.Color.Empty;
+//        //public Color BorderColor = Color.Empty;
 //        private string strLink = null;
 //        /// <summary>
 //        /// link
@@ -1544,8 +1545,8 @@ namespace RtfDomParser
 //            this.Italic = false;
 //            this.Underline = false;
 //            this.Strikeout = false;
-//            this.TextColor = System.Drawing.Color.Black;
-//            this.BackColor = System.Drawing.Color.Empty;
+//            this.TextColor = Color.Black;
+//            this.BackColor = Color.Empty;
 //            //this.Link = null ;
 //            this.Subscript = false;
 //            this.Superscript = false;
@@ -1567,7 +1568,7 @@ namespace RtfDomParser
 //            //this.TopBorder = false;
 //            //this.RightBorder = false;
 //            //this.BottomBorder = false;
-//            //this.BorderColor = System.Drawing.Color.Transparent;
+//            //this.BorderColor = Color.Transparent;
 //        }
 
 //        public void Reset()
@@ -1584,8 +1585,8 @@ namespace RtfDomParser
 //            this.Italic = false;
 //            this.Underline = false;
 //            this.Strikeout = false;
-//            this.TextColor = System.Drawing.Color.Black;
-//            this.BackColor = System.Drawing.Color.Empty;
+//            this.TextColor = Color.Black;
+//            this.BackColor = Color.Empty;
 //            this.Link = null;
 //            this.Subscript = false;
 //            this.Superscript = false;

--- a/Source/RtfDomParser/ProgressEventHandler.cs
+++ b/Source/RtfDomParser/ProgressEventHandler.cs
@@ -8,7 +8,6 @@
  */
 
 using System;
-using System.Text;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/RTFAlignment.cs
+++ b/Source/RtfDomParser/RTFAlignment.cs
@@ -9,9 +9,6 @@
 
 
 
-using System;
-using System.Text;
-
 namespace RtfDomParser
 {
     /// <summary>

--- a/Source/RtfDomParser/RTFAttribute.cs
+++ b/Source/RtfDomParser/RTFAttribute.cs
@@ -10,7 +10,6 @@
 
 
 using System;
-using System.Text;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/RTFBorderStyle.cs
+++ b/Source/RtfDomParser/RTFBorderStyle.cs
@@ -7,12 +7,9 @@
  * 
  */
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Drawing ;
-using System.Drawing.Drawing2D;
+using SixLabors.ImageSharp ;
 using System.ComponentModel;
+using RtfDomParser.Utils;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/RTFColorTable.cs
+++ b/Source/RtfDomParser/RTFColorTable.cs
@@ -9,8 +9,9 @@
 
 
 
-using System;
 using System.Collections ;
+using RtfDomParser.Utils;
+using SixLabors.ImageSharp;
 
 namespace RtfDomParser
 {
@@ -32,11 +33,11 @@ namespace RtfDomParser
 		/// <summary>
 		/// get color at special index
 		/// </summary>
-		public System.Drawing.Color this[ int index ]
+		public Color this[ int index ]
 		{
 			get
             {
-                return ( System.Drawing.Color ) myItems[ index ] ;
+                return ( Color ) myItems[ index ] ;
             }
 		}
 
@@ -46,12 +47,12 @@ namespace RtfDomParser
 		/// <param name="index">index</param>
 		/// <param name="DefaultValue">default value</param>
 		/// <returns>color value</returns>
-		public System.Drawing.Color GetColor( int index , System.Drawing.Color DefaultValue )
+		public Color GetColor( int index , Color DefaultValue )
 		{
 			index -- ;
             if (index >= 0 && index < myItems.Count)
             {
-                return (System.Drawing.Color)myItems[index];
+                return (Color)myItems[index];
             }
             else
             {
@@ -79,16 +80,19 @@ namespace RtfDomParser
 		/// add color to list
 		/// </summary>
 		/// <param name="c">new color value</param>
-		public void Add( System.Drawing.Color c )
+		public void Add( Color c )
 		{
-			if( c.IsEmpty )
+			if( c == ImageTools.ColorEmpty )
 				return ;
-			if( c.A == 0 )
+
+            var A = c.GetAlpha();
+
+            if ( A == 0 )
 				return ;
 			
-			if( c.A != 255 )
+			if( A != 255 )
 			{
-				c = System.Drawing.Color.FromArgb( 255 , c );
+				c = c.WithAlpha(255);
 			}
 
             if (bolCheckValueExistWhenAdd)
@@ -107,7 +111,7 @@ namespace RtfDomParser
 		/// delete special color
 		/// </summary>
 		/// <param name="c">color value</param>
-		public void Remove( System.Drawing.Color c )
+		public void Remove( Color c )
 		{
 			int index = IndexOf( c );
 			if( index >= 0 )
@@ -118,19 +122,21 @@ namespace RtfDomParser
 		/// </summary>
 		/// <param name="c">color</param>
 		/// <returns>index , if not found , return -1</returns>
-		public int IndexOf( System.Drawing.Color c )
-		{
-            if (c.A == 0)
+		public int IndexOf( Color c )
+        {
+            var A = c.GetAlpha();
+
+            if (A == 0)
             {
                 return -1;
             }
-			if( c.A != 255 )
+			if( A != 255 )
 			{
-				c = System.Drawing.Color.FromArgb( 255 , c );
+				c = c.WithAlpha(255);
 			}
             for (int iCount = 0; iCount < myItems.Count; iCount++)
             {
-                System.Drawing.Color color = (System.Drawing.Color)myItems[iCount];
+                Color color = (Color)myItems[iCount];
                 if (color.ToArgb() == c.ToArgb())
                 {
                     return iCount;
@@ -139,14 +145,14 @@ namespace RtfDomParser
 			return -1 ;
 		}
 		/// <summary>
-		/// Çå¿ÕÁÐ±í
+		/// ï¿½ï¿½ï¿½ï¿½Ð±ï¿½
 		/// </summary>
 		public void Clear()
 		{
 			myItems.Clear();
 		}
 		/// <summary>
-		/// ÔªËØ¸öÊý
+		/// Ôªï¿½Ø¸ï¿½ï¿½ï¿½
 		/// </summary>
 		public int Count
 		{
@@ -154,9 +160,9 @@ namespace RtfDomParser
 		}
 
 		/// <summary>
-		/// Êä³öÑÕÉ«±í
+		/// ï¿½ï¿½ï¿½ï¿½ï¿½É«ï¿½ï¿½
 		/// </summary>
-		/// <param name="writer">RTFÎÄµµÊéÐ´Æ÷</param>
+		/// <param name="writer">RTFï¿½Äµï¿½ï¿½ï¿½Ð´ï¿½ï¿½</param>
 		public void Write( RTFWriter writer )
 		{
 			writer.WriteStartGroup();
@@ -164,7 +170,8 @@ namespace RtfDomParser
 			writer.WriteRaw(";");
 			for( int iCount = 0 ; iCount < myItems.Count ; iCount ++ )
 			{
-				System.Drawing.Color c = ( System.Drawing.Color ) myItems[ iCount ] ;
+				Color ic = ( Color ) myItems[ iCount ] ;
+                var c = ic.Extract();
 				writer.WriteKeyword( "red" + c.R );
 				writer.WriteKeyword( "green" + c.G );
 				writer.WriteKeyword( "blue" + c.B );
@@ -174,15 +181,15 @@ namespace RtfDomParser
 		}
 
         /// <summary>
-        /// ¸´ÖÆ¶ÔÏó
+        /// ï¿½ï¿½ï¿½Æ¶ï¿½ï¿½ï¿½
         /// </summary>
-        /// <returns>¸´ÖÆÆ·</returns>
+        /// <returns>ï¿½ï¿½ï¿½ï¿½Æ·</returns>
         public RTFColorTable Clone()
         {
             RTFColorTable table = new RTFColorTable();
             for (int iCount = 0; iCount < myItems.Count; iCount++)
             {
-                System.Drawing.Color c = ( System.Drawing.Color ) myItems[ iCount ] ;
+                Color c = ( Color ) myItems[ iCount ] ;
                 table.myItems.Add(c);
             }
             return table;

--- a/Source/RtfDomParser/RTFConsts.cs
+++ b/Source/RtfDomParser/RTFConsts.cs
@@ -7,7 +7,6 @@
  * 
  */
 
-using System;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/RTFDocumentWriter.cs
+++ b/Source/RtfDomParser/RTFDocumentWriter.cs
@@ -11,6 +11,10 @@
 
 using System;
 using System.Collections ;
+using RtfDomParser.Utils;
+using SixLabors.Fonts;
+using SixLabors.ImageSharp;
+
 //using DCSoft.Drawing ;
 //using DCSoft.Printing ;
 
@@ -206,23 +210,23 @@ namespace RtfDomParser
                 }
             }
         }
-		public void WriteBorderLineDashStyle( System.Drawing.Drawing2D.DashStyle style )
+		public void WriteBorderLineDashStyle( DashStyle style )
 		{
 			if( bolCollectionInfo == false )
 			{
-				if( style == System.Drawing.Drawing2D.DashStyle.Dot )
+				if( style == DashStyle.Dot )
 				{
 					this.WriteKeyword("brdrdot");
 				}
-				else if( style == System.Drawing.Drawing2D.DashStyle.DashDot )
+				else if( style == DashStyle.DashDot )
 				{
 					this.WriteKeyword("brdrdashd");
 				}
-				else if( style == System.Drawing.Drawing2D.DashStyle.DashDotDot )
+				else if( style == DashStyle.DashDotDot )
 				{
 					this.WriteKeyword("brdrdashdd");
 				}
-				else if( style == System.Drawing.Drawing2D.DashStyle.Dash )
+				else if( style == DashStyle.Dash )
 				{
 					this.WriteKeyword("brdrdash");
 				}
@@ -235,7 +239,7 @@ namespace RtfDomParser
 
         private bool _DebugMode = true;
         /// <summary>
-        /// 处于调试模式
+        /// 锟斤拷锟节碉拷锟斤拷模式
         /// </summary>
         public bool DebugMode
         {
@@ -332,7 +336,8 @@ namespace RtfDomParser
 				myWriter.WriteRaw(";");
 				for( int iCount = 0 ; iCount < myColorTable.Count ; iCount ++ )
 				{
-					System.Drawing.Color c = myColorTable[ iCount ] ;
+					Color ic = myColorTable[ iCount ] ;
+                    var c = ic.Extract();
 					myWriter.WriteKeyword( "red" + c.R );
 					myWriter.WriteKeyword( "green" + c.G );
 					myWriter.WriteKeyword( "blue" + c.B );
@@ -679,7 +684,7 @@ namespace RtfDomParser
 		/// write font format
 		/// </summary>
 		/// <param name="font">font</param>
-		public void WriteFont( System.Drawing.Font font )
+		public void WriteFont( Font font )
 		{
 			if( font == null )
 			{
@@ -696,22 +701,26 @@ namespace RtfDomParser
 				{
 					myWriter.WriteKeyword( "f" + index );
 				}
-				if( font.Bold )
+				if( font.IsBold )
 				{
 					myWriter.WriteKeyword("b");
 				}
-				if( font.Italic )
+				if( font.IsItalic )
 				{
 					myWriter.WriteKeyword("i");
 				}
+				/* TODO
 				if( font.Underline )
 				{
 					myWriter.WriteKeyword("ul");
 				}
+				*/
+				/* TODO
 				if( font.Strikeout )
 				{
 					myWriter.WriteKeyword("strike");
 				}
+				*/
 				myWriter.WriteKeyword("fs" + Convert.ToInt32( font.Size * 2 ));
 			}
 		}
@@ -730,7 +739,7 @@ namespace RtfDomParser
                 myFontTable.Add(info.FontName);
                 myColorTable.Add(info.TextColor);
                 myColorTable.Add(info.BackColor);
-                if (info.BorderColor.A != 0)
+                if (info.BorderColor.GetAlpha() != 0)
                 {
                     myColorTable.Add(info.BorderColor);
                 }
@@ -809,7 +818,7 @@ namespace RtfDomParser
                 || info.BottomBorder)
             {
                 // border color
-                if (info.BorderColor.A != 0)
+                if (info.BorderColor.GetAlpha() != 0)
                 {
                     myWriter.WriteKeyword("chbrdr");
                     myWriter.WriteKeyword("brdrs");
@@ -953,7 +962,7 @@ namespace RtfDomParser
 		/// <param name="width">pixel width</param>
 		/// <param name="height">pixel height</param>
 		/// <param name="ImageData">image binary data</param>
-		public void WriteImage( System.Drawing.Image img , int width , int height , byte[] ImageData )
+		public void WriteImage( Image img , int width , int height , byte[] ImageData )
 		{
 			if( this.bolCollectionInfo )
 			{
@@ -965,17 +974,17 @@ namespace RtfDomParser
 					return ;
 
 				System.IO.MemoryStream ms = new System.IO.MemoryStream();
-				img.Save( ms , System.Drawing.Imaging.ImageFormat.Jpeg );
+                img.SaveAsJpeg(ms);
 				ms.Close();
 				byte[] bs = ms.ToArray();
 				myWriter.WriteStartGroup();
 				
 				myWriter.WriteKeyword("pict");
 				myWriter.WriteKeyword("jpegblip");
-				myWriter.WriteKeyword("picscalex" + Convert.ToInt32( width * 100.0 / img.Size.Width ));
-				myWriter.WriteKeyword("picscaley" + Convert.ToInt32( height * 100.0 / img.Size.Height ));
-				myWriter.WriteKeyword("picwgoal" + Convert.ToString( img.Size.Width * 15 ));
-				myWriter.WriteKeyword("pichgoal" + Convert.ToString( img.Size.Height * 15 ));
+				myWriter.WriteKeyword("picscalex" + Convert.ToInt32( width * 100.0 / img.Width ));
+				myWriter.WriteKeyword("picscaley" + Convert.ToInt32( height * 100.0 / img.Height ));
+				myWriter.WriteKeyword("picwgoal" + Convert.ToString( img.Width * 15 ));
+				myWriter.WriteKeyword("pichgoal" + Convert.ToString( img.Height * 15 ));
 				myWriter.WriteBytes( bs );
 				myWriter.WriteEndGroup();
 			}

--- a/Source/RtfDomParser/RTFDomBookmark.cs
+++ b/Source/RtfDomParser/RTFDomBookmark.cs
@@ -10,7 +10,6 @@
 
 
 using System;
-using System.Text;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/RTFDomDocument.cs
+++ b/Source/RtfDomParser/RTFDomDocument.cs
@@ -12,8 +12,8 @@ using System.Collections;
 using System.Text;
 using System.ComponentModel ;
 using System.Collections.Generic;
-using System.Drawing ;
-using System.Drawing.Drawing2D ;
+using RtfDomParser.Utils;
+using SixLabors.ImageSharp;
 
 namespace RtfDomParser
 {
@@ -495,7 +495,7 @@ namespace RtfDomParser
         }
 
         /// <summary>
-        /// ½«ÎÄµµÖÐËùÓÐµÄÄÚÈÝ¶¼·ÅÖÃÔÚ¶ÎÂäÖÐ¡£
+        /// ï¿½ï¿½ï¿½Äµï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ðµï¿½ï¿½ï¿½ï¿½Ý¶ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ú¶ï¿½ï¿½ï¿½ï¿½Ð¡ï¿½
         /// </summary>
         public void FixForParagraphs( RTFDomElement parentElement )
         {
@@ -611,7 +611,7 @@ namespace RtfDomParser
             }
 
 
-            //// É¾³ýÁÙÊ±Éú³ÉµÄ¶ÍÁ¶¶ÔÏó£¬½«¶ÎÂäÕûÌåÍùÉÏ´í¶¯ÒÆ¶¯Ò»Î»
+            //// É¾ï¿½ï¿½ï¿½ï¿½Ê±ï¿½ï¿½ï¿½ÉµÄ¶ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ó£¬½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ï´ï¿½ï¿½ï¿½ï¿½Æ¶ï¿½Ò»Î»
             //RTFDomParagraph tempP = null;
             //RTFDomParagraph lastP = null;
             //foreach (RTFDomElement element in parentElement.Elements)
@@ -637,7 +637,7 @@ namespace RtfDomParser
             //}//foreach
             //if (tempP != null && lastP != null)
             //{
-            //    // Èô·¢Éú¶ÍÁ¶ÏòÉÏ´íÎ»ÒÆ¶¯£¬¶øÇÒ×îºóÒ»¸ö¶ÎÂäÎª¿Õ£¬ÔòÉ¾³ý×îºóÒ»¸ö¶ÎÂä¡£
+            //    // ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ï´ï¿½Î»ï¿½Æ¶ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ò»ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Îªï¿½Õ£ï¿½ï¿½ï¿½É¾ï¿½ï¿½ï¿½ï¿½ï¿½Ò»ï¿½ï¿½ï¿½ï¿½ï¿½ä¡£
             //    if (lastP.Elements.Count == 0)
             //    {
             //        parentElement.Elements.Remove(lastP);
@@ -910,9 +910,9 @@ namespace RtfDomParser
         }
 
         /// <summary>
-        /// ½«±í¸ñÐÐÔªËØºÏ²¢³É±í¸ñÔªËØ
+        /// ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ôªï¿½ØºÏ²ï¿½ï¿½É±ï¿½ï¿½ï¿½Ôªï¿½ï¿½
         /// </summary>
-        /// <param name="parentElement">¸¸ÔªËØ¶ÔÏó</param>
+        /// <param name="parentElement">ï¿½ï¿½Ôªï¿½Ø¶ï¿½ï¿½ï¿½</param>
         private void CombinTable(RTFDomElement parentElement)
         {
             ArrayList result = new ArrayList();
@@ -1104,7 +1104,7 @@ namespace RtfDomParser
                 RTFDomTableRow row = (RTFDomTableRow)table.Elements[iCount];
                 if (row.Elements.Count == 0)
                 {
-                    // É¾³ýÃ»ÓÐÄÚÈÝµÄ±í¸ñÐÐ
+                    // É¾ï¿½ï¿½Ã»ï¿½ï¿½ï¿½ï¿½ï¿½ÝµÄ±ï¿½ï¿½ï¿½ï¿½ï¿½
                     table.Elements.RemoveAt(iCount);
                 }
             }
@@ -1247,13 +1247,13 @@ namespace RtfDomParser
                     }
                     for (int iCount = cell.Attributes.Count - 1; iCount >= 0; iCount--)
                     {
-                        // ¸ù¾Ý brdrtbl Ö¸ÁîÀ´Òþ²ØÄ³Ìõµ¥Ôª¸ñ±ß¿òÏß
+                        // ï¿½ï¿½ï¿½ï¿½ brdrtbl Ö¸ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ä³ï¿½ï¿½ï¿½ï¿½Ôªï¿½ï¿½ß¿ï¿½ï¿½ï¿½
                         string name3 = cell.Attributes.GetItem(iCount).Name;
                         if ( name3 == RTFConsts._brdrtbl 
                             || name3 == RTFConsts._brdrnone 
                             || name3 == RTFConsts._brdrnil )
                         {
-                            // Ä³¸ö±ß¿ò²»ÏÔÊ¾
+                            // Ä³ï¿½ï¿½ï¿½ß¿ï¿½ï¿½ï¿½Ê¾
                             for (int iCount2 = iCount - 1; iCount2 >= 0; iCount2--)
                             {
                                 string name2 = cell.Attributes.GetItem(iCount2).Name;
@@ -1704,7 +1704,7 @@ namespace RtfDomParser
                     switch (reader.Keyword)
                     {
                         case "fromhtml":
-                            // ÒÔHTML·½Ê½¶ÁÈ¡ÎÄµµÄÚÈÝ
+                            // ï¿½ï¿½HTMLï¿½ï¿½Ê½ï¿½ï¿½È¡ï¿½Äµï¿½ï¿½ï¿½ï¿½ï¿½
                             ReadHtmlContent(reader);
                             return;
                         case RTFConsts._listtable:
@@ -2000,9 +2000,9 @@ namespace RtfDomParser
                                 }
                                 else
                                 {
-                                    // ½áÊøµ±Ç°¶ÎÂä
+                                    // ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ç°ï¿½ï¿½ï¿½ï¿½
                                     this.CompleteParagraph();
-                                    // ´´½¨ÐÂµÄ¶ÎÂä
+                                    // ï¿½ï¿½ï¿½ï¿½ï¿½ÂµÄ¶ï¿½ï¿½ï¿½
                                     RTFDomParagraph p = new RTFDomParagraph();
                                     p.Format = _ParagraphFormat;
                                     AddContentElement(p);
@@ -2012,7 +2012,7 @@ namespace RtfDomParser
                             }
                         case RTFConsts._page:
                             {
-                                // Ç¿ÖÆ·ÖÒ³
+                                // Ç¿ï¿½Æ·ï¿½Ò³
                                 bolStartContent = true;
                                 this.CompleteParagraph();
                                 this.AddContentElement(new RTFDomPageBreak());
@@ -2020,7 +2020,7 @@ namespace RtfDomParser
                             }
                         case RTFConsts._pagebb:
                             {
-                                // ÔÚ¶ÎÂäÇ°Ç¿ÖÆ·ÖÒ³
+                                // ï¿½Ú¶ï¿½ï¿½ï¿½Ç°Ç¿ï¿½Æ·ï¿½Ò³
                                 bolStartContent = true;
                                 _ParagraphFormat.PageBreak = true;
                                 break;
@@ -2272,7 +2272,7 @@ namespace RtfDomParser
                                 {
                                     if (reader.HasParam)
                                     {
-                                        format.TextColor = this.ColorTable.GetColor( reader.Parameter, System.Drawing.Color.Black);
+                                        format.TextColor = this.ColorTable.GetColor( reader.Parameter, Color.Black);
                                     }
                                 }
                                 break;
@@ -2287,7 +2287,7 @@ namespace RtfDomParser
                                 {
                                     if ( reader.HasParam )
                                     {
-                                        format.BackColor = this.ColorTable.GetColor(reader.Parameter, System.Drawing.Color.Empty);
+                                        format.BackColor = this.ColorTable.GetColor(reader.Parameter, ImageTools.ColorEmpty);
                                     }
                                 }
                                 break;
@@ -2329,7 +2329,7 @@ namespace RtfDomParser
                                     {
                                         format.BackColor = this.ColorTable.GetColor(
                                             reader.Parameter ,
-                                            System.Drawing.Color.Empty );
+                                            ImageTools.ColorEmpty );
                                     }
                                 }
                                 break;
@@ -2914,7 +2914,7 @@ namespace RtfDomParser
                                     if (reader.Parameter == 0)
                                     {
                                         // is the 0 level , belong to document , not to a table
-                                        // £¿£¿£¿£¿£¿£¿ \itap0¹¦ÄÜ²»Ã÷£¬¿´À´»¹ÊÇÒÔ \cellÖ¸ÁîÎª×¼
+                                        // ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ \itap0ï¿½ï¿½ï¿½Ü²ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ \cellÖ¸ï¿½ï¿½Îª×¼
                                         //foreach (RTFDomElement element in es)
                                         //{
                                         //    if (element is RTFDomTableRow || element is RTFDomTableCell)
@@ -3168,7 +3168,7 @@ namespace RtfDomParser
                 }
                 else if (reader.TokenType == RTFTokenType.GroupStart)
                 {
-                    // ¶ÁÈ¡Ò»Ìõ¼ÇÂ¼
+                    // ï¿½ï¿½È¡Ò»ï¿½ï¿½ï¿½ï¿½Â¼
                     int level = reader.Level;
                     RTFListOverride record = null;
                     while (reader.ReadToken() != null)
@@ -3340,7 +3340,7 @@ namespace RtfDomParser
                         {
                             if (reader.CurrentToken.Key != "list")
                             {
-                                // ²»ÊÇÒÔlist¿ªÍ·£¬ºöÂÔµô
+                                // ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½listï¿½ï¿½Í·ï¿½ï¿½ï¿½ï¿½ï¿½Ôµï¿½
                                 ReadToEndGround(reader);
                                 reader.ReadToken();
                                 break;
@@ -3536,7 +3536,7 @@ namespace RtfDomParser
                     case ";":
                         if (r >= 0 && g >= 0 && b >= 0)
                         {
-                            System.Drawing.Color c = System.Drawing.Color.FromArgb(255, r, g, b);
+                            Color c = ImageTools.FromArgb(255, r, g, b);
                             myColorTable.Add(c);
                             r = -1;
                             g = -1;
@@ -3548,7 +3548,7 @@ namespace RtfDomParser
             if (r >= 0 && g >= 0 && b >= 0)
             {
                 // read the last color
-                System.Drawing.Color c = System.Drawing.Color.FromArgb(255, r, g, b);
+                Color c = ImageTools.FromArgb(255, r, g, b);
                 myColorTable.Add(c);
             }
         }
@@ -3823,7 +3823,7 @@ namespace RtfDomParser
                         obj.ScaleY = reader.Parameter;
                         break;
                     case RTFConsts._result :
-                        // ¶ÁÈ¡¶ÔÏóÔËËã½á¹ûÊý¾Ý
+                        // ï¿½ï¿½È¡ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
                         RTFDomElementContainer result = new RTFDomElementContainer();
                         result.Name = RTFConsts._result;
                         obj.AppendChild(result);
@@ -4026,7 +4026,8 @@ namespace RtfDomParser
             builder.Append( Environment.NewLine + "   ColorTable(" + myColorTable.Count + ")");
             for (int iCount = 0; iCount < myColorTable.Count; iCount ++ )
             {
-                System.Drawing.Color c = myColorTable[iCount];
+                Color ic = myColorTable[iCount];
+                var c = ic.Extract();
                 builder.Append(Environment.NewLine + "      " + iCount + ":" + c.R + " " + c.G + " " + c.B );
             }
             builder.Append(Environment.NewLine + "   FontTable(" + myFontTable.Count + ")");

--- a/Source/RtfDomParser/RTFDomElement.cs
+++ b/Source/RtfDomParser/RTFDomElement.cs
@@ -10,8 +10,6 @@
 
 using System;
 using System.Text;
-using System.Collections;
-using System.ComponentModel;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/RTFDomElementContainer.cs
+++ b/Source/RtfDomParser/RTFDomElementContainer.cs
@@ -8,7 +8,6 @@
  */
 
 using System;
-using System.Text;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/RTFDomElementList.cs
+++ b/Source/RtfDomParser/RTFDomElementList.cs
@@ -10,7 +10,6 @@
 
 
 using System;
-using System.Text;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/RTFDomField.cs
+++ b/Source/RtfDomParser/RTFDomField.cs
@@ -9,7 +9,6 @@
 
 
 using System;
-using System.Text;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/RTFDomHeader.cs
+++ b/Source/RtfDomParser/RTFDomHeader.cs
@@ -8,8 +8,6 @@
  */
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/RTFDomImage.cs
+++ b/Source/RtfDomParser/RTFDomImage.cs
@@ -10,7 +10,6 @@
 
 
 using System;
-using System.Text;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/RTFDomLineBreak.cs
+++ b/Source/RtfDomParser/RTFDomLineBreak.cs
@@ -10,7 +10,6 @@
 
 
 using System;
-using System.Text;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/RTFDomObject.cs
+++ b/Source/RtfDomParser/RTFDomObject.cs
@@ -9,7 +9,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/RTFDomPageBreak.cs
+++ b/Source/RtfDomParser/RTFDomPageBreak.cs
@@ -8,8 +8,6 @@
  */
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/RTFDomShape.cs
+++ b/Source/RtfDomParser/RTFDomShape.cs
@@ -10,7 +10,6 @@
 
 
 using System;
-using System.Text;
 using System.ComponentModel ;
 
 namespace RtfDomParser

--- a/Source/RtfDomParser/RTFDomShapeGroup.cs
+++ b/Source/RtfDomParser/RTFDomShapeGroup.cs
@@ -10,7 +10,6 @@
 
 
 using System;
-using System.Text;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/RTFDomTable.cs
+++ b/Source/RtfDomParser/RTFDomTable.cs
@@ -9,7 +9,6 @@
 
 
 using System;
-using System.Text;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/RTFDomTableCell.cs
+++ b/Source/RtfDomParser/RTFDomTableCell.cs
@@ -10,7 +10,6 @@
 
 
 using System;
-using System.Text;
 
 namespace RtfDomParser
 {
@@ -338,12 +337,12 @@ namespace RtfDomParser
             }
         }
 
-        //private System.Drawing.Color intBorderColor = System.Drawing.Color.Black;
+        //private Color intBorderColor = Color.Black;
         ///// <summary>
         ///// border color
         ///// </summary>
-        //[System.ComponentModel.DefaultValue(typeof(System.Drawing.Color), "Black")]
-        //public System.Drawing.Color BorderColor
+        //[System.ComponentModel.DefaultValue(typeof(Color), "Black")]
+        //public Color BorderColor
         //{
         //    get
         //    {
@@ -355,12 +354,12 @@ namespace RtfDomParser
         //    }
         //}
 
-        //private System.Drawing.Color intBackColor = System.Drawing.Color.Transparent;
+        //private Color intBackColor = Color.Transparent;
         ///// <summary>
         ///// back color
         ///// </summary>
-        //[System.ComponentModel.DefaultValue(typeof(System.Drawing.Color), "Transparent")]
-        //public System.Drawing.Color BackColor
+        //[System.ComponentModel.DefaultValue(typeof(Color), "Transparent")]
+        //public Color BackColor
         //{
         //    get
         //    {

--- a/Source/RtfDomParser/RTFDomTableColumn.cs
+++ b/Source/RtfDomParser/RTFDomTableColumn.cs
@@ -10,7 +10,6 @@
 
 
 using System;
-using System.Text;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/RTFDomTableRow.cs
+++ b/Source/RtfDomParser/RTFDomTableRow.cs
@@ -10,7 +10,6 @@
 
 
 using System;
-using System.Text;
 using System.ComponentModel;
 using System.Collections;
 

--- a/Source/RtfDomParser/RTFDomTempContainer.cs
+++ b/Source/RtfDomParser/RTFDomTempContainer.cs
@@ -7,9 +7,6 @@
  * 
  */
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/RTFFontTable.cs
+++ b/Source/RtfDomParser/RTFFontTable.cs
@@ -9,7 +9,6 @@
 
 
 using System;
-using System.Collections ;
 using System.Collections.Generic ;
 using System.Text ;
 

--- a/Source/RtfDomParser/RTFInstanceDebugView.cs
+++ b/Source/RtfDomParser/RTFInstanceDebugView.cs
@@ -9,7 +9,6 @@
 
 
 using System;
-using System.Text;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/RTFListOverrideTable.cs
+++ b/Source/RtfDomParser/RTFListOverrideTable.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/RTFListTable.cs
+++ b/Source/RtfDomParser/RTFListTable.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/RTFNode.cs
+++ b/Source/RtfDomParser/RTFNode.cs
@@ -9,7 +9,6 @@
 
 
 
-using System;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/RTFNodeGroup.cs
+++ b/Source/RtfDomParser/RTFNodeGroup.cs
@@ -7,7 +7,6 @@
  * 
  */
 
-using System;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/RTFNodeType.cs
+++ b/Source/RtfDomParser/RTFNodeType.cs
@@ -8,7 +8,6 @@
  */
 
 
-using System;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/RTFRawDocument.cs
+++ b/Source/RtfDomParser/RTFRawDocument.cs
@@ -8,6 +8,8 @@
  */
 
 using System;
+using RtfDomParser.Utils;
+using SixLabors.ImageSharp;
 
 namespace RtfDomParser
 {
@@ -182,7 +184,7 @@ namespace RtfDomParser
                 {
                     if (r >= 0 && g >= 0 && b >= 0)
                     {
-                        System.Drawing.Color c = System.Drawing.Color.FromArgb(255, r, g, b);
+                        Color c = ImageTools.FromArgb(255, r, g, b);
                         myColorTable.Add(c);
                         r = -1;
                         g = -1;
@@ -193,7 +195,7 @@ namespace RtfDomParser
             if (r >= 0 && g >= 0 && b >= 0)
             {
                 // read the last color
-                System.Drawing.Color c = System.Drawing.Color.FromArgb(255, r, g, b);
+                Color c = ImageTools.FromArgb(255, r, g, b);
                 myColorTable.Add(c);
             }
         }

--- a/Source/RtfDomParser/RTFRawLayerInfo.cs
+++ b/Source/RtfDomParser/RTFRawLayerInfo.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace RtfDomParser
+﻿namespace RtfDomParser
 {
     public class RTFRawLayerInfo
     {

--- a/Source/RtfDomParser/RTFUtil.cs
+++ b/Source/RtfDomParser/RTFUtil.cs
@@ -10,10 +10,6 @@
 
 using System;
 using System.Runtime.InteropServices ;
-using System.IO ;
-using System.Drawing ;
-using System.Drawing.Imaging ;
-using System.Text ;
 
 namespace RtfDomParser
 {
@@ -25,10 +21,10 @@ namespace RtfDomParser
 
 
         /// <summary>
-        /// ÅÐ¶Ï¶ÔÏóÊÇ·ñÓÐÊµ¼ÊÄÚÈÝ
+        /// ï¿½Ð¶Ï¶ï¿½ï¿½ï¿½ï¿½Ç·ï¿½ï¿½ï¿½Êµï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
         /// </summary>
-        /// <param name="rootElement">¸ùÔªËØ¶ÔÏó</param>
-        /// <returns>ÊÇ·ñÓÐÊµ¼ÊÄÚÈÝ</returns>
+        /// <param name="rootElement">ï¿½ï¿½Ôªï¿½Ø¶ï¿½ï¿½ï¿½</param>
+        /// <returns>ï¿½Ç·ï¿½ï¿½ï¿½Êµï¿½ï¿½ï¿½ï¿½ï¿½ï¿½</returns>
         public static bool HasContentElement(RTFDomElement rootElement)
         {
             if (rootElement.Elements.Count == 0)
@@ -94,6 +90,7 @@ namespace RtfDomParser
 
 
 
+		/*
 		/// <summary>
 		/// Wraps the image in an Enhanced Metafile by drawing the image onto the
 		/// graphics context, then converts the Enhanced Metafile to a Windows
@@ -136,7 +133,7 @@ namespace RtfDomParser
 				_stream = new MemoryStream();
 
 				// Get a graphics context from the RichTextBox
-				using(_graphics = System.Drawing.Graphics.FromHwnd( new IntPtr( 0 ) ))
+				using(_graphics = Graphics.FromHwnd( new IntPtr( 0 ) ))
 				{
 
 					// Get the device context from the graphics context
@@ -154,7 +151,7 @@ namespace RtfDomParser
 				{
 
 					// Draw the image on the Enhanced Metafile
-					_graphics.DrawImage(_image, new Rectangle(0, 0, _image.Width, _image.Height));
+                    _graphics.DrawImage(_image, new Rectangle(0, 0, _image.Width, _image.Height));
 
 				}
 
@@ -193,6 +190,7 @@ namespace RtfDomParser
 					_stream.Close();
 			}
 		}
+		*/
   
 
 		private RTFUtil()

--- a/Source/RtfDomParser/RTFVerticalAlignment.cs
+++ b/Source/RtfDomParser/RTFVerticalAlignment.cs
@@ -8,8 +8,6 @@
  */
 
 
-using System;
-
 namespace RtfDomParser
 {
     /// <summary>

--- a/Source/RtfDomParser/RTFWriter.cs
+++ b/Source/RtfDomParser/RTFWriter.cs
@@ -9,7 +9,6 @@
 
 
 
-using System;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/RtfDomParser.csproj
+++ b/Source/RtfDomParser/RtfDomParser.csproj
@@ -19,7 +19,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="System.Drawing.Common" Version="5.0.3" />
+	  <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta19" />
+	  <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
 	</ItemGroup>
 
 </Project>

--- a/Source/RtfDomParser/RtfDomParser.csproj
+++ b/Source/RtfDomParser/RtfDomParser.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net5.0</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 		<PackageId>RtfDomParserCore</PackageId>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<PackageProjectUrl>https://github.com/brianberns/RtfDomParser</PackageProjectUrl>
 		<Authors>Nikolay.IT, yuan yong fu, Brian Berns</Authors>
 		<Company />
 		<Description>RtfDomParser (a.k.a. DCSoft.RTF and XDesigner.RTF) is an open source C# library for parsing RTF documents and generating RTF DOM Tree. This version supports .NET Core.</Description>
-		<Version>1.0.2</Version>
+		<Version>1.0.3</Version>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -19,7 +19,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
+	  <PackageReference Include="System.Drawing.Common" Version="5.0.3" />
 	</ItemGroup>
 
 </Project>

--- a/Source/RtfDomParser/StringAttribute.cs
+++ b/Source/RtfDomParser/StringAttribute.cs
@@ -8,7 +8,6 @@
  */
 
 using System;
-using System.Text;
 
 namespace RtfDomParser
 {

--- a/Source/RtfDomParser/Utils/DashStyle.cs
+++ b/Source/RtfDomParser/Utils/DashStyle.cs
@@ -1,0 +1,35 @@
+﻿namespace RtfDomParser.Utils
+{
+    public enum DashStyle
+    {
+        /// <summary>
+        /// Specifies a solid line.
+        /// </summary>
+        Solid = 0,
+
+        /// <summary>
+        /// Specifies a line consisting of dashes.
+        /// </summary>
+        Dash = 1,
+
+        /// <summary>
+        /// Specifies a line consisting of dots.
+        /// </summary>
+        Dot = 2,
+
+        /// <summary>
+        /// Specifies a line consisting of a repeating pattern of dash-dot.
+        /// </summary>
+        DashDot = 3,
+
+        /// <summary>
+        /// Specifies a line consisting of a repeating pattern of dash-dot-dot.
+        /// </summary>
+        DashDotDot = 4,
+
+        /// <summary>
+        /// Specifies a user-defined custom dash style.
+        /// </summary>
+        Custom = 5
+    }
+}

--- a/Source/RtfDomParser/Utils/ImageTools.cs
+++ b/Source/RtfDomParser/Utils/ImageTools.cs
@@ -1,0 +1,36 @@
+﻿using System.Numerics;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace RtfDomParser.Utils
+{
+    internal static class ImageTools
+    {
+        public static int GetAlpha(this Color color)
+        {
+            return (int)((Vector4)color).W;
+        }
+
+        public static (int R, int G, int B, int A) Extract(this Color color)
+        {
+            var vector = (Vector4)color;
+            var r = (int)vector.X;
+            var g = (int)vector.Y;
+            var b = (int)vector.Z;
+            var a = (int)vector.W;
+            return (R: r, G: g, B: b, A: a);
+        }
+
+        public static uint ToArgb(this Color color)
+        {
+            return color.ToPixel<Argb32>().Argb;
+        }
+
+        public static Color FromArgb(int a, int r, int g, int b)
+        {
+            return Color.FromRgba((byte)r, (byte)g, (byte)b, (byte)a);
+        }
+
+        public static Color ColorEmpty => default;
+    }
+}

--- a/Source/RtfDomParser/Utils/StringAlignment.cs
+++ b/Source/RtfDomParser/Utils/StringAlignment.cs
@@ -1,0 +1,20 @@
+﻿namespace RtfDomParser.Utils
+{
+    public enum StringAlignment
+    {
+        /// <summary>
+        /// Specifies the text be aligned near the layout. In a left-to-right layout, the near position is left. In a right-to-left layout, the near position is right.
+        /// </summary>
+        Near = 0,
+
+        /// <summary>
+        /// Specifies that text is aligned in the center of the layout rectangle.
+        /// </summary>
+        Center = 1,
+
+        /// <summary>
+        /// Specifies that text is aligned far from the origin position of the layout rectangle. In a left-to-right layout, the far position is right. In a right-to-left layout, the far position is left.
+        /// </summary>
+        Far = 2
+    }
+}


### PR DESCRIPTION
I wanted to remove System.Drawing.Common, because its version starting with 6.0 is not crossplatform anymore. 
So I replaced it with SixLabors.ImageSharp and I guess that's better.